### PR TITLE
Add pygmentize as dependency

### DIFF
--- a/texlive/Dockerfile
+++ b/texlive/Dockerfile
@@ -11,6 +11,7 @@ RUN \
 		biber \
 		texlive-most \
 		texlive-lang \
+		pygmentize \
 	`# Clear pacman cache` \
 	&& pacman -Scc --noconfirm
 


### PR DESCRIPTION
I added pygementize as a dependency. This allows me (and others) to use `minted` listings.