### PR TITLE
Install dependencies for `latexindent`

### DIFF
--- a/texlive/Dockerfile
+++ b/texlive/Dockerfile
@@ -20,6 +20,13 @@ RUN \
 # other Perl-based paths for the sake of completeness. [1]
 ENV PATH="/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:${PATH}"
 
+# Install dependencies for latexindent.
+RUN  (echo y;echo o conf prerequisites_policy follow;echo o conf commit)|cpan \ 
+	 && cpan install Log::Dispatch::File \
+	 && cpan install YAML::Tiny \
+	 && cpan install File::HomeDir \
+	 && rm -Rf $HOME/.cpan 
+	 
 CMD ["tail", "-f", "/dev/null"]
 
 # REFERENCES


### PR DESCRIPTION
I'm not sure if this is something you want in the repo, but I added it to my branch. 

It installs the dependencies for `latexindent` (after the path so that `cpan` is found). 
The `~/.cpan` directory is then nuked because its no longer necessary. I'm unsure if there is other stuff that can be removed, though.